### PR TITLE
Add minimal example

### DIFF
--- a/examples/Minimal.re
+++ b/examples/Minimal.re
@@ -1,0 +1,14 @@
+ let region =
+   ReactNativeMaps.Region.create(
+     ~latitudeDelta=0.0922,
+     ~longitudeDelta=0.0421,
+     ~latitude=0.0, ~longitude=0.0
+   );
+
+ let styles =
+   StyleSheet.create({"map": StyleSheet.absoluteFillObject});
+
+ [@react.component]
+ let make = () => {
+   <MapView region style={styles##map} />;
+ };


### PR DESCRIPTION
It took me way too long to figure out that I needed `StyleSheet.absoluteFillObject` for the map to show up. I was assuming I haven't set up the API key correctly or I'd missed some linking step. Having a minimal example would have helped immensely. 